### PR TITLE
Make tasks more consistent

### DIFF
--- a/tasks/02_record_images.md
+++ b/tasks/02_record_images.md
@@ -2,7 +2,11 @@
 title: Save Image Link
 ---
 
-#### As a user I want to be able to save a link to an image.
+#### As a user I want to save a link to an image.
 
 Acceptance criteria:
 - [ ] The link is entered through a form.
+- [ ] After the form is saved, the link is persisted in the database.
+
+Dependencies:
+- Deployment Environment

--- a/tasks/03_display_images.md
+++ b/tasks/03_display_images.md
@@ -6,8 +6,8 @@ title: Image Index
 
 Acceptance criteria:
 - [ ] New images that are added show up on the homepage.
-- [ ] These images are persisted (if the browser is closed or even if the
-  server is restarted).
+- [ ] These images are persisted if the browser is closed or even if the
+  server is restarted.
 - [ ] Images are not displayed wider than 400px.
 
 Dependencies:

--- a/tasks/03_display_images.md
+++ b/tasks/03_display_images.md
@@ -5,4 +5,10 @@ title: Image Index
 #### As a user I want the homepage to display all saved images.
 
 Acceptance criteria:
+- [ ] New images that are added show up on the homepage.
+- [ ] These images are persisted (if the browser is closed or even if the
+  server is restarted).
 - [ ] Images are not displayed wider than 400px.
+
+Dependencies:
+- Save Image Link

--- a/tasks/04_delete_image.md
+++ b/tasks/04_delete_image.md
@@ -6,3 +6,7 @@ title: Delete Image
 
 Acceptance criteria:
 - [ ] The user is prompted for confirmation prior to deletion.
+- [ ] Deleted images are removed from the homepage.
+
+Dependencies:
+- Image Index

--- a/tasks/05_valid_urls.md
+++ b/tasks/05_valid_urls.md
@@ -2,11 +2,15 @@
 title: Image URL Validation
 ---
 
-#### As a user I want only valid image URLs to be submitted.
+#### As a user I want to be prevented from submitting invalid image URLs.
 
 Acceptance criteria:
+- [ ] I cannot successfully save an image with an invalid URL.
 - [ ] An error message is associated with the appropriate input field on
   failure.
 
 Discussion Topic:
 - [ ] What is a valid image URL?
+
+Dependencies:
+- Save Image Link

--- a/tasks/06_seed_file.md
+++ b/tasks/06_seed_file.md
@@ -9,3 +9,6 @@ Acceptance criteria:
   homepage.
 - [ ] When a new app is deployed on heroku (e.g., every review app), that app
   has at least 20 images on its homepage.
+
+Dependencies:
+- Image Index

--- a/tasks/07_capybara_testing.md
+++ b/tasks/07_capybara_testing.md
@@ -9,11 +9,10 @@ Acceptance criteria:
 - [ ] I have added a test for the "delete an existing image" flow.
 - [ ] Any additional flows I've added to my application before this story are
   tested.
-- [ ] Going forward, I will add capybara tests during regular feature
-  development (rather than as separate stories).
 
 Discussion topics:
 - [ ] What can you test in flow tests that you cannot test in controller tests?
+- [ ] Going forward, when should we add flow tests?
 - [ ] What are the tradeoffs between different drivers for capybara?
 - [ ] How can Capybara help us with timing issues in our tests?
 - [ ] How can we keep our tests DRY?

--- a/tasks/07_capybara_testing.md
+++ b/tasks/07_capybara_testing.md
@@ -2,16 +2,15 @@
 title: Capybara Testing
 ---
 
-#### As a developer I am using capybara to test complete flows in my application.
+#### As a developer I want to use capybara to test complete flows in my application.
 
 Acceptance criteria:
-- [ ] I have added a test for the "add a new image" flow
-- [ ] I have added a test for the "edit an existing image" flow
-- [ ] I have added a test for the "delete an existing image" flow
+- [ ] I have added a test for the "add a new image" flow.
+- [ ] I have added a test for the "delete an existing image" flow.
 - [ ] Any additional flows I've added to my application before this story are
-  tested
+  tested.
 - [ ] Going forward, I will add capybara tests during regular feature
-  development (rather than as separate stories)
+  development (rather than as separate stories).
 
 Discussion topics:
 - [ ] What can you test in flow tests that you cannot test in controller tests?
@@ -22,3 +21,7 @@ Discussion topics:
 Reference material:
 - https://github.com/jnicklas/capybara
 - Tip 3 from http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
+
+Dependencies:
+- Image URL Validation
+- Delete Image

--- a/tasks/08_add_tags.md
+++ b/tasks/08_add_tags.md
@@ -5,5 +5,14 @@ title: Image Tags
 #### As a user I want to add tags to images.
 
 Acceptance criteria:
-- [ ] Use [acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on)
-  to provide the tagging functionality.
+- [ ] When I add a new image, there is a form field to add tags.
+- [ ] After I've saved an image with tags, I see those tags displayed with the
+  associated image on the index page.
+- [ ] My application uses the acts-as-taggable-on gem to provide the tagging
+  functionality.
+
+Reference material:
+- https://github.com/mbleigh/acts-as-taggable-on
+
+Dependencies:
+- Image Index

--- a/tasks/09_images_by_tag.md
+++ b/tasks/09_images_by_tag.md
@@ -10,6 +10,7 @@ Acceptance criteria:
 - [ ] The tag name (not its ID) is used to perform the filtering.
 
 Discussion topics:
+- Where should we implement this functionality?
 - What happens if a user tries to manually filter by a nonexistent tag?
 
 Dependencies:

--- a/tasks/09_images_by_tag.md
+++ b/tasks/09_images_by_tag.md
@@ -5,4 +5,12 @@ title: Images by Tag
 #### As a user I want to view all images associated with a tag.
 
 Acceptance criteria:
-- [ ] The tag name, not its ID, should be used to perform the filtering.
+- [ ] When I click on a tag, I see a filtered list of only the images that have
+  the tag I clicked on. 
+- [ ] The tag name (not its ID) is used to perform the filtering.
+
+Discussion topics:
+- What happens if a user tries to manually filter by a nonexistent tag?
+
+Dependencies:
+- Image Tags

--- a/tasks/10_tag_list.md
+++ b/tasks/10_tag_list.md
@@ -5,5 +5,9 @@ title: Tag Index
 #### As a user I want to see a list of tags and the number of images associated with each.
 
 Acceptance criteria:
-- [ ] The tag list should be sorted by frequency with the most common first.
-- [ ] The tag name should link to the image list for the tag.
+- [ ] There is a link in the application that takes me to a list of all tags.
+- [ ] The tag list is sorted by frequency with the most common first.
+- [ ] Each tag name is a link to the image list filtered by that tag.
+
+Dependencies:
+- Images by Tag

--- a/tasks/11_mandatory_tag.md
+++ b/tasks/11_mandatory_tag.md
@@ -5,5 +5,9 @@ title: Required Tag Association
 #### As a user I want all images to have at least one tag.
 
 Acceptance criteria:
+- [ ] I cannot save an image without adding at least one tag.
 - [ ] An error message is associated with the appropriate input field when a
   tag is not provided.
+
+Dependencies:
+- Image Tags

--- a/tasks/12_modify_tag_list.md
+++ b/tasks/12_modify_tag_list.md
@@ -2,7 +2,14 @@
 title: Modify Tag List
 ---
 
-#### As a user I want to be able to edit the tag list for an image.
+#### As a user I want to edit the tag list for an image.
 
 Acceptance criteria:
+- [ ] There is a link to edit the tags for an image.
 - [ ] The image whose tags are to be modified is displayed on the edit page.
+- [ ] On the edit page, I can change the tags to any valid tag list.
+- [ ] After saving the edit page with valid tags, my changes are visible
+  throughout the rest of the application.
+
+Dependencies:
+- Image Tags

--- a/tasks/13_es6_configuration.md
+++ b/tasks/13_es6_configuration.md
@@ -2,15 +2,15 @@
 title: ES6 Configuration
 ---
 
-#### As a developer I can use the latest and greatest javascript features, including ES6 modules, in my application.
+#### As a developer I want to use the latest and greatest javascript features, including ES6 modules, in my application.
 
 Acceptance criteria:
 - [ ] I can develop using ES6 modules and they will be transpiled to supported
-  syntax
-- [ ] I have configured my production setup to support this transpilation
-- [ ] A "hello world" ES6 module has been added to the application
+  syntax.
+- [ ] I have configured my production setup to support this transpilation.
+- [ ] A "hello world" ES6 module has been added to the application.
 - [ ] I know how to include javascript modules only on a given page, as 
-  demonstrated by only including this "hello world" module on the images index
+  demonstrated by only including this "hello world" module on the images index.
 
 Discussion topics:
 - [ ] What are the benefits of using ES6 modules?
@@ -21,3 +21,6 @@ Reference material:
 
 Further reading:
 - List of ES6 features: http://git.io/es6features
+
+Dependencies:
+- Image Index

--- a/tasks/14_share_image.md
+++ b/tasks/14_share_image.md
@@ -2,10 +2,12 @@
 title: Share Image
 ---
 
-#### As a user I can share an image via email.
+#### As a user I want to share an image with someone via email.
 
 Acceptance criteria:
-- [ ] A bootstrap modal should appear with a form to send the email.
+- [ ] There is a link to share an image.
+- [ ] After clicking on this link, a bootstrap modal appears with a form to
+  send the email.
 - [ ] The modal closes and a success message is shown if the email was sent
   successfully.
 - [ ] The user is alerted of errors if the operation was unsuccessful.

--- a/tasks/15_content_security_policy.md
+++ b/tasks/15_content_security_policy.md
@@ -2,7 +2,7 @@
 title: Content Security Policy
 ---
 
-#### As a security-minded developer, I want to obviate all cross site scripting (XSS) attacks.
+#### As a security-minded developer I want to obviate all cross site scripting (XSS) attacks.
 
 A strong content security policy can be used to prevent XSS and other
 attacks. With many things security related, it is a good idea to disallow
@@ -27,4 +27,7 @@ Acceptance criteria:
 
 
 Reference material:
-- https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheet
+- https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheeti
+
+Dependencies:
+- Image Index


### PR DESCRIPTION
- All tasks (except the first) list the task(s) on which they depend

- All user stories are of the form: "As a ___ I want ____" (where the second
  blank does *not* start with "to be able to")

- Tasks that had incomplete acceptance criteria are now more fully fleshed out